### PR TITLE
Update bindings for ctypes-0.6 compatibility.

### DIFF
--- a/bindings/ffi_bindings.ml
+++ b/bindings/ffi_bindings.ml
@@ -68,39 +68,41 @@ module Bindings (F : Cstubs.FOREIGN) =
 struct
   let foreign = F.foreign
 
+  let ((@=>), ret) = Ctypes.(F.((@->), returning))
+
   let err_get_error = foreign "ERR_get_error"
-    Ctypes.(void @-> returning ulong)
+    Ctypes.(void @=> ret ulong)
 
   let err_error_string_n = foreign "ERR_error_string_n"
-    Ctypes.(ulong @-> ptr char @-> int @-> returning void)
+    Ctypes.(ulong @=> ptr char @=> int @=> ret void)
 
   let add_all_digests = foreign "OpenSSL_add_all_digests"
-    Ctypes.(void @-> returning void)
+    Ctypes.(void @=> ret void)
 
   let add_all_ciphers = foreign "OpenSSL_add_all_ciphers"
-    Ctypes.(void @-> returning void)
+    Ctypes.(void @=> ret void)
 
   let init = foreign "SSL_library_init"
-    Ctypes.(void @-> returning ulong)
+    Ctypes.(void @=> ret ulong)
 
   let ssl_load_error_strings = foreign "SSL_load_error_strings"
-    Ctypes.(void @-> returning void)
+    Ctypes.(void @=> ret void)
 
   module Ssl_ctx =
   struct
     let t = Ctypes.(ptr void)
 
     let new_ = foreign "SSL_CTX_new"
-      Ctypes.(ptr void @-> returning (ptr_opt void))
+      Ctypes.(ptr void @=> ret (ptr_opt void))
 
     let free = foreign "SSL_CTX_free"
-      Ctypes.(t @-> returning void)
+      Ctypes.(t @=> ret void)
 
     let load_verify_locations = foreign "SSL_CTX_load_verify_locations"
-      Ctypes.(t @-> string_opt @-> string_opt @-> returning int)
+      Ctypes.(t @=> string_opt @=> string_opt @=> ret int)
 
     let set_session_id_context = foreign "SSL_CTX_set_session_id_context"
-      Ctypes.(t @-> ptr char @-> uint @-> returning int)
+      Ctypes.(t @=> ptr char @=> uint @=> ret int)
   end
 
   module Bio =
@@ -108,76 +110,76 @@ struct
     let t = Ctypes.(ptr void) (* for use in ctypes signatures *)
 
     let new_ = foreign "BIO_new"
-      Ctypes.(ptr void @-> returning t)
+      Ctypes.(ptr void @=> ret t)
 
     let s_mem = foreign "BIO_s_mem"
-      Ctypes.(void @-> returning (ptr void))
+      Ctypes.(void @=> ret (ptr void))
 
     let read = foreign "BIO_read"
-      Ctypes.(t @-> ptr char @-> int @-> returning int)
+      Ctypes.(t @=> ptr char @=> int @=> ret int)
 
     let write = foreign "BIO_write"
-      Ctypes.(t @-> string @-> int @-> returning int)
+      Ctypes.(t @=> string @=> int @=> ret int)
   end
 
   module ASN1_object = struct
     let t = Ctypes.(ptr void)
 
     let obj2nid = foreign "OBJ_obj2nid"
-      Ctypes.(t @-> returning int)
+      Ctypes.(t @=> ret int)
 
     let nid2sn = foreign "OBJ_nid2sn"
-      Ctypes.(int @-> returning string_opt)
+      Ctypes.(int @=> ret string_opt)
   end
 
   module ASN1_string = struct
     let t = Ctypes.(ptr void)
 
     let length = foreign "ASN1_STRING_length"
-      Ctypes.(t @-> returning int)
+      Ctypes.(t @=> ret int)
 
     let data = foreign "ASN1_STRING_data"
-      Ctypes.(t @-> returning string)
+      Ctypes.(t @=> ret string)
   end
 
   module X509_name_entry = struct
     let t = Ctypes.(ptr void)
 
     let get_object = foreign "X509_NAME_ENTRY_get_object"
-      Ctypes.(t @-> returning ASN1_object.t)
+      Ctypes.(t @=> ret ASN1_object.t)
 
     let get_data = foreign "X509_NAME_ENTRY_get_data"
-      Ctypes.(t @-> returning ASN1_string.t)
+      Ctypes.(t @=> ret ASN1_string.t)
   end
 
   module X509_name = struct
     let t = Ctypes.(ptr void)
 
     let entry_count = foreign "X509_NAME_entry_count"
-      Ctypes.(t @-> returning int)
+      Ctypes.(t @=> ret int)
 
     let get_entry = foreign "X509_NAME_get_entry"
-      Ctypes.(t @-> int @-> returning X509_name_entry.t)
+      Ctypes.(t @=> int @=> ret X509_name_entry.t)
   end
 
   module X509 = struct
     let t = Ctypes.(ptr void)
 
     let get_subject_name = foreign "X509_get_subject_name"
-      Ctypes.(t @-> returning X509_name.t)
+      Ctypes.(t @=> ret X509_name.t)
 
     let verify_cert_error_string = foreign "X509_verify_cert_error_string"
-      Ctypes.(long @-> returning string_opt)
+      Ctypes.(long @=> ret string_opt)
   end
 
   module Ssl_session = struct
     let t = Ctypes.(ptr void)
 
     let new_ = foreign "SSL_SESSION_new"
-      Ctypes.(void @-> returning t)
+      Ctypes.(void @=> ret t)
 
     let free = foreign "SSL_SESSION_free"
-      Ctypes.(t @-> returning void)
+      Ctypes.(t @=> ret void)
   end
 
   module Ssl =
@@ -185,66 +187,66 @@ struct
     let t = Ctypes.(ptr void)
 
     let new_ = foreign "SSL_new"
-      Ctypes.(Ssl_ctx.t @-> returning t)
+      Ctypes.(Ssl_ctx.t @=> ret t)
 
     let free = foreign "SSL_free"
-      Ctypes.(t @-> returning void)
+      Ctypes.(t @=> ret void)
 
     let set_method = foreign "SSL_set_ssl_method"
-      Ctypes.(t @-> ptr void @-> returning int)
+      Ctypes.(t @=> ptr void @=> ret int)
 
     let get_error = foreign "SSL_get_error"
-      Ctypes.(ptr void @-> int @-> returning int)
+      Ctypes.(ptr void @=> int @=> ret int)
 
     let set_connect_state = foreign "SSL_set_connect_state"
-      Ctypes.(t @-> returning void)
+      Ctypes.(t @=> ret void)
 
     let set_accept_state = foreign "SSL_set_accept_state"
-      Ctypes.(t @-> returning void)
+      Ctypes.(t @=> ret void)
 
     let connect = foreign "SSL_connect"
-      Ctypes.(t @-> returning int)
+      Ctypes.(t @=> ret int)
 
     let accept = foreign "SSL_accept"
-      Ctypes.(t @-> returning int)
+      Ctypes.(t @=> ret int)
 
     let set_bio = foreign "SSL_set_bio"
-      Ctypes.(t @-> Bio.t @-> Bio.t @-> returning void)
+      Ctypes.(t @=> Bio.t @=> Bio.t @=> ret void)
 
     let read = foreign "SSL_read"
-      Ctypes.(t @-> ptr char @-> int @-> returning int)
+      Ctypes.(t @=> ptr char @=> int @=> ret int)
 
     let write = foreign "SSL_write"
-      Ctypes.(t @-> string @-> int @-> returning int)
+      Ctypes.(t @=> string @=> int @=> ret int)
 
     let use_certificate_file = foreign "SSL_use_certificate_file"
-      Ctypes.(t @-> string @-> int @-> returning int)
+      Ctypes.(t @=> string @=> int @=> ret int)
 
     let use_private_key_file = foreign "SSL_use_PrivateKey_file"
-      Ctypes.(t @-> string @-> int @-> returning int)
+      Ctypes.(t @=> string @=> int @=> ret int)
 
     let set_verify = foreign "SSL_set_verify"
-      Ctypes.(t @-> int @-> ptr void @-> returning void)
+      Ctypes.(t @=> int @=> ptr void @=> ret void)
 
     let get_peer_certificate = foreign "SSL_get_peer_certificate"
-      Ctypes.(t @-> returning X509.t)
+      Ctypes.(t @=> ret X509.t)
 
     let get_verify_result = foreign "SSL_get_verify_result"
-      Ctypes.(t @-> returning long)
+      Ctypes.(t @=> ret long)
 
     let get_version = foreign "SSL_get_version"
-      Ctypes.(t @-> returning string)
+      Ctypes.(t @=> ret string)
 
     let set_session = foreign "SSL_set_session"
-      Ctypes.(t @-> Ssl_session.t @-> returning int)
+      Ctypes.(t @=> Ssl_session.t @=> ret int)
 
     let session_reused = foreign "SSL_session_reused"
-      Ctypes.(t @-> returning int)
+      Ctypes.(t @=> ret int)
 
     let get1_session = foreign "SSL_get1_session"
-      Ctypes.(t @-> returning Ssl_session.t)
+      Ctypes.(t @=> ret Ssl_session.t)
 
     let check_private_key = foreign "SSL_check_private_key"
-      Ctypes.(t @-> returning int)
+      Ctypes.(t @=> ret int)
   end
 end

--- a/src/ffi_generated.mli
+++ b/src/ffi_generated.mli
@@ -1,4 +1,3 @@
 open Ctypes_packed
-type 'a fn = 'a
-val foreign : string -> ('a -> 'b) Ctypes.fn -> ('a -> 'b)
-val foreign_value : string -> 'a Ctypes.typ -> 'a Ctypes.ptr
+include Cstubs.FOREIGN
+  with type 'a return = 'a and type 'a result = 'a


### PR DESCRIPTION
The next release of ctypes will include a small backwards-incompatible change to the `Cstubs` interface: `@->` and `returning` used in a bindings functor should now be imported from the functor argument, not from `Ctypes`.  The type of the generated ML module has changed accordingly.

See the following PR for more details: https://github.com/ocamllabs/ocaml-ctypes/pull/389

This pull request:
  * changes the `Ffi_bindings` module to be compatible both with existing versions of ctypes and with the forthcoming 0.6 release, and
  * changes the `mli` file for `Ffi_generated` to support the signature generated by ctypes 0.6.  The signature is no longer compatible with earlier versions of ctypes.

From the `async_ssl` code it appears that the preferred style is to avoid non-local opens except for a few distinguished modules such as `Core.Std`, so I've followed that convention in this patch.