### PR TITLE
SNI (Server Name Indication) for Ssl.client

### DIFF
--- a/bindings/ffi_bindings.ml
+++ b/bindings/ffi_bindings.ml
@@ -285,5 +285,8 @@ struct
 
     let check_private_key = foreign "SSL_check_private_key"
       Ctypes.(t @-> returning int)
+
+    let set_tlsext_host_name = foreign "SSL_set_tlsext_host_name"
+      Ctypes.(t @-> ptr char @-> returning int)
   end
 end

--- a/src/ffi.ml
+++ b/src/ffi.ml
@@ -436,4 +436,12 @@ module Ssl = struct
     | 1 -> Ok ()
     | _ -> Or_error.error "SSL_check_private_key error"
              (get_error_stack ()) [%sexp_of: string list]
+
+  let set_tlsext_host_name context hostname =
+    let hostname = Ctypes.(coerce string (ptr char)) hostname in
+    match Bindings.Ssl.set_tlsext_host_name context hostname with
+    | 1 -> Ok ()
+    | 0 -> Or_error.error "SSL_set_tlsext_host_name error"
+                   (get_error_stack ()) [%sexp_of: string list]
+    | n -> failwithf "OpenSSL bug: SSL_set_tlsext_host_name returned %d" n ()
 end

--- a/src/ffi.mli
+++ b/src/ffi.mli
@@ -201,6 +201,8 @@ module Ssl : sig
   val set_session : t -> Ssl_session.t -> unit Or_error.t
 
   val get1_session : t -> Ssl_session.t option
+
+  val set_tlsext_host_name : t -> string -> unit Or_error.t
 end
 
 (** Pops all errors off of the openssl error stack, returning them as a list of

--- a/src/ssl.mli
+++ b/src/ssl.mli
@@ -111,6 +111,7 @@ end
 val client
   :  ?version:Version.t
   -> ?name:string
+  -> ?hostname:string
   -> ?ca_file:string
   -> ?ca_path:string
   -> ?session:Session.t


### PR DESCRIPTION
Ssl.client can set the hostname parameter of the SNI TLS extension.
