### PR TITLE
Fix build on ubuntu, libraries need to come after objects that use them

### DIFF
--- a/bindings/jbuild
+++ b/bindings/jbuild
@@ -9,7 +9,7 @@
 (rule
  ((targets (discover.exe))
   (deps    (discover.c openssl-ccopt openssl-cclib))
-  (action "${CC} $(< openssl-ccopt) $(< openssl-cclib) -ldl discover.c -o discover.exe")))
+  (action "${CC} $(< openssl-ccopt) discover.c $(< openssl-cclib) -ldl -o discover.exe")))
 
 (rule
  ((targets (config.h))

--- a/bindings/openssl-flags.sh
+++ b/bindings/openssl-flags.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 set -e
 


### PR DESCRIPTION
See https://wiki.ubuntu.com/NattyNarwhal/ToolchainTransition

Also fix ./openssl-flags.sh: 22: ./openssl-flags.sh: Bad substitution