### PR TITLE
Support the new OpenSSL TLS_method

### DIFF
--- a/bindings/discover.c
+++ b/bindings/discover.c
@@ -4,6 +4,7 @@
 
 static char * const symbol[] = { "SSLv3_method",
                                  "SSLv23_method",
+                                 "TLS_method",
                                  "TLSv1_method",
                                  "TLSv1_1_method",
                                  "TLSv1_2_method",

--- a/bindings/ffi_bindings.ml
+++ b/bindings/ffi_bindings.ml
@@ -95,6 +95,13 @@ struct
       dummy
 #endif
 
+    let tls = helper "TLS_method"
+#ifdef JSC_TLS_method
+      implemented
+#else
+      dummy
+#endif
+
     let tlsv1 = helper "TLSv1_method"
 #ifdef JSC_TLSv1_method
       implemented
@@ -116,11 +123,13 @@ struct
       dummy
 #endif
 
-    let sslv23 = helper "SSLv23_method"
+    let sslv23 =
 #ifdef JSC_SSLv23_method
-      implemented
+      helper "SSLv23_method" implemented
+#elifdef JSC_TLS_method
+      tls
 #else
-      dummy
+      helper "SSLv23_method" dummy
 #endif
 
     (* SSLv2 isn't secure, so we don't use it.  If you really really really need it, use


### PR DESCRIPTION
In the newest version, OpenSSL replaced `SSLv23_method` with
`TLS_method`, then used a macro to link the two. Since we can't
detect the macro, it was not being found.

This causes us to look for `TLS_method` and then use it as a
replacement for `SSLv23_method` if necessary.

Fixes #27 