### PR TITLE
`SSL_set1_groups_list` returns 1 for success

### DIFF
--- a/src/ffi__library_must_be_initialized.ml
+++ b/src/ffi__library_must_be_initialized.ml
@@ -543,8 +543,8 @@ module Ssl = struct
 
   let set1_groups_list_exn t groups =
     match Bindings.Ssl.set1_groups_list t (String.concat ~sep:":" groups) with
-    | 0 -> ()
-    | 1 ->
+    | 1 -> ()
+    | 0 ->
       failwithf !"SSL_set1_groups_list error: %{sexp:string list}" (get_error_stack ()) ()
     | n -> failwithf "OpenSSL bug: SSL_set1_groups_list returned %d" n ()
   ;;


### PR DESCRIPTION
`SSL_CTX_set1_groups_list` returns 1 for success and 0 for failure.

https://www.openssl.org/docs/man3.0/man3/SSL_set1_groups_list.html

It looks like the condition to check if the response from `SSL_set1_groups_list` is an error was flipped. It leads to exceptions like so when attempting to use async_ssl from janestreet's 0.16.x branch.

```
(monitor.ml.Error
 (exn.ml.Reraised
  "Shuttle.Connection: Unhandled exception in TCP client connection"
  (monitor.ml.Error (Failure "SSL_set1_groups_list error: ()")
   ("Raised at Stdlib.failwith in file \"stdlib.ml\", line 29, characters 17-33"
    "Called from Async_ssl__Ssl.Connection.create_exn in file \"src/ssl.ml\", line 120, characters 4-61"
    "Called from Async_ssl__Ssl.Connection.create_client_exn in file \"src/ssl.ml\", line 150, characters 4-192"
    "Called from Async_kernel__Deferred0.bind.(fun) in file \"src/deferred0.ml\", line 54, characters 64-69"
    "Called from Async_kernel__Job_queue.run_jobs in file \"src/job_queue.ml\", line 180, characters 6-47")))
```