### PR TITLE
Use openssl's host validation support

### DIFF
--- a/bindings/ffi_bindings.ml
+++ b/bindings/ffi_bindings.ml
@@ -181,6 +181,15 @@ module Types (F : Cstubs.Types.TYPE) = struct
   module Evp = struct
     let max_md_size = F.constant "EVP_MAX_MD_SIZE" F.int
   end
+
+  module X509_check_host = struct
+    let always_check_subject = F.constant "X509_CHECK_FLAG_ALWAYS_CHECK_SUBJECT" F.int
+    let never_check_subject = F.constant "X509_CHECK_FLAG_NEVER_CHECK_SUBJECT" F.int
+    let no_wildcards = F.constant "X509_CHECK_FLAG_NO_WILDCARDS" F.int
+    let no_partial_wildcards = F.constant "X509_CHECK_FLAG_NO_PARTIAL_WILDCARDS" F.int
+    let multi_label_wildcards = F.constant "X509_CHECK_FLAG_MULTI_LABEL_WILDCARDS" F.int
+    let single_label_subdomains = F.constant "X509_CHECK_FLAG_SINGLE_LABEL_SUBDOMAINS" F.int
+  end
 end
 
 module Bindings (F : Cstubs.FOREIGN) = struct
@@ -601,6 +610,9 @@ module Bindings (F : Cstubs.FOREIGN) = struct
     let set_verify =
       foreign "SSL_set_verify" Ctypes.(t @-> int @-> ptr void @-> returning void)
     ;;
+
+    let set1_host = foreign "SSL_set1_host" Ctypes.(t @-> string @-> returning int)
+    let set_hostflags = foreign "SSL_set_hostflags" Ctypes.(t @-> int @-> returning void)
 
     let set_cipher_list =
       foreign "SSL_set_cipher_list" Ctypes.(t @-> string @-> returning int)

--- a/bindings/ffi_bindings.ml
+++ b/bindings/ffi_bindings.ml
@@ -183,12 +183,12 @@ module Types (F : Cstubs.Types.TYPE) = struct
   end
 
   module X509_check_host = struct
-    let always_check_subject = F.constant "X509_CHECK_FLAG_ALWAYS_CHECK_SUBJECT" F.int
-    let never_check_subject = F.constant "X509_CHECK_FLAG_NEVER_CHECK_SUBJECT" F.int
-    let no_wildcards = F.constant "X509_CHECK_FLAG_NO_WILDCARDS" F.int
-    let no_partial_wildcards = F.constant "X509_CHECK_FLAG_NO_PARTIAL_WILDCARDS" F.int
-    let multi_label_wildcards = F.constant "X509_CHECK_FLAG_MULTI_LABEL_WILDCARDS" F.int
-    let single_label_subdomains = F.constant "X509_CHECK_FLAG_SINGLE_LABEL_SUBDOMAINS" F.int
+    let always_check_subject = F.constant "X509_CHECK_FLAG_ALWAYS_CHECK_SUBJECT" F.uint
+    let never_check_subject = F.constant "X509_CHECK_FLAG_NEVER_CHECK_SUBJECT" F.uint
+    let no_wildcards = F.constant "X509_CHECK_FLAG_NO_WILDCARDS" F.uint
+    let no_partial_wildcards = F.constant "X509_CHECK_FLAG_NO_PARTIAL_WILDCARDS" F.uint
+    let multi_label_wildcards = F.constant "X509_CHECK_FLAG_MULTI_LABEL_WILDCARDS" F.uint
+    let single_label_subdomains = F.constant "X509_CHECK_FLAG_SINGLE_LABEL_SUBDOMAINS" F.uint
   end
 end
 
@@ -612,7 +612,7 @@ module Bindings (F : Cstubs.FOREIGN) = struct
     ;;
 
     let set1_host = foreign "SSL_set1_host" Ctypes.(t @-> string @-> returning int)
-    let set_hostflags = foreign "SSL_set_hostflags" Ctypes.(t @-> int @-> returning void)
+    let set_hostflags = foreign "SSL_set_hostflags" Ctypes.(t @-> uint @-> returning void)
 
     let set_cipher_list =
       foreign "SSL_set_cipher_list" Ctypes.(t @-> string @-> returning int)

--- a/src/dune
+++ b/src/dune
@@ -12,7 +12,7 @@
 
 (library (name async_ssl) (public_name async_ssl)
  (modules import version opt verify_mode ffi_generated_types ffi_generated
-  ffi__library_must_be_initialized rfc3526 ssl initialize std config tls)
+  ffi__library_must_be_initialized rfc3526 ssl initialize std config tls x509_check_host)
  (c_names ffi_generated_stubs) (flags :standard -w -9-27-32-34)
  (c_flags (:standard \ -Werror -pedantic -Wall -Wunused) -w
   (:include ../bindings/openssl-ccopt.sexp))

--- a/src/ffi__library_must_be_initialized.ml
+++ b/src/ffi__library_must_be_initialized.ml
@@ -474,7 +474,7 @@ module Ssl = struct
   ;;
 
   let set_hostflags t flags =
-    let flags = List.map flags ~f:X509_check_host.to_int |> List.fold ~init:0 ~f:Int.bit_or in
+    let flags = List.map flags ~f:X509_check_host.to_int |> List.fold ~init:(Unsigned.UInt.zero) ~f:Unsigned.UInt.logor in
     Bindings.Ssl.set_hostflags t flags
   ;;
 

--- a/src/ffi__library_must_be_initialized.mli
+++ b/src/ffi__library_must_be_initialized.mli
@@ -199,6 +199,8 @@ module Ssl : sig
 
   val check_private_key : t -> unit Or_error.t
   val set_verify : t -> Verify_mode.t list -> unit
+  val set1_host : t -> string -> unit
+  val set_hostflags : t -> X509_check_host.t list -> unit
   val get_peer_certificate : t -> X509.t option
   val get_peer_certificate_fingerprint : t -> [ `SHA1 ] -> string option
 

--- a/src/ssl.mli
+++ b/src/ssl.mli
@@ -9,6 +9,7 @@ open! Async
 module Version : module type of Version
 module Opt : module type of Opt
 module Verify_mode : module type of Verify_mode
+module X509_check_host : module type of X509_check_host
 
 val secure_ciphers : string list
 
@@ -147,6 +148,7 @@ val client
   :  ?version:Version.t
   -> ?options:Opt.t list
   -> ?name:string
+  -> ?host_validation_mode:X509_check_host.t list
   -> ?hostname:string
   (** Use [allowed_ciphers] to control which ciphers should be used.  See CIPHERS(1), and
       `openssl ciphers -v`.

--- a/src/x509_check_host.ml
+++ b/src/x509_check_host.ml
@@ -1,0 +1,10 @@
+(* https://www.openssl.org/docs/man3.0/man3/X509_check_host.html *)
+
+type t =
+  | AlwaysCheckSubject
+  | NeverCheckSubject
+  | NoWildcards
+  | NoPartialWildcards
+  | MultiLabelWildcards
+  | SingleLabelSubdomains
+[@@deriving sexp_of]

--- a/stubgen/ffi_types_stubgen.ml
+++ b/stubgen/ffi_types_stubgen.ml
@@ -1,6 +1,6 @@
 module Ffi_bindings = Async_ssl_bindings.Ffi_bindings
 
-let prologue = "\n#include <openssl/ssl.h>\n#include <openssl/err.h>\n"
+let prologue = "\n#include <openssl/ssl.h>\n#include <openssl/err.h>\n#include <openssl/x509v3.h>\n"
 
 let () =
   print_endline prologue;


### PR DESCRIPTION
Use OpenSSL's built-in functionality for hostname validation. This was added to OpenSSL 1.1.0, and using this feature will ensure that whenever a user provides a hostname for an ssl client, openssl will verify that the hostname in the peer certificate actually matches it.

https://wiki.openssl.org/index.php/Hostname_validation

Signed-off-by: Anurag Soni <anurag@sonianurag.com>