### PR TITLE
Fix for openssl 3.1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 _build
+_opam
 *.install
 *.merlin
-_opam
 *.DS_Store

--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,4 @@ _build
 *.install
 *.merlin
 _opam
-
+*.DS_Store

--- a/bindings/ctypes_foreign_flat.ml
+++ b/bindings/ctypes_foreign_flat.ml
@@ -2,7 +2,6 @@ module Ctypes_closure_properties     = Ctypes_closure_properties
 module Ctypes_ffi                    = Ctypes_ffi
 module Ctypes_ffi_stubs              = Ctypes_ffi_stubs
 module Ctypes_foreign_basis          = Ctypes_foreign_basis
-module Ctypes_foreign_threaded_stubs = Ctypes_foreign_threaded_stubs
 module Ctypes_weak_ref               = Ctypes_weak_ref
 module Dl                            = Dl
 module Foreign                       = Foreign

--- a/bindings/ffi_bindings.ml
+++ b/bindings/ffi_bindings.ml
@@ -342,10 +342,6 @@ module Bindings (F : Cstubs.FOREIGN) = struct
       foreign "ENGINE_load_builtin_engines" Ctypes.(void @-> returning void)
     ;;
 
-    let unregister_RAND =
-      foreign "ENGINE_unregister_RAND" Ctypes.(void @-> returning void)
-    ;;
-
     let register_all_complete =
       foreign "ENGINE_register_all_complete" Ctypes.(void @-> returning void)
     ;;

--- a/dune-project
+++ b/dune-project
@@ -1,1 +1,1 @@
-(lang dune 1.10)
+(lang dune 1.11)

--- a/src/initialize.ml
+++ b/src/initialize.ml
@@ -23,8 +23,6 @@ let initialize () =
     Bindings.openssl_config None;
     (* Make hardware accelaration available *)
     Bindings.Engine.load_builtin_engines ();
-    (* But unload RAND because RDRAND is suspected to have been compromised *)
-    Bindings.Engine.unregister_RAND ();
     (* Finish engine registration *)
     Bindings.Engine.register_all_complete ();
     (* SSL_library_init() initializes the SSL algorithms.

--- a/src/ssl.ml
+++ b/src/ssl.ml
@@ -641,7 +641,7 @@ let client
   Option.iter session ~f:(Session.remember ~conn);
   don't_wait_for
     (Connection.with_cleanup conn ~f:(fun () -> Connection.start_loops conn)
-     >>| Ivar.fill_exn conn.closed);
+     >>| Ivar.fill conn.closed);
   return (Ok conn)
 ;;
 
@@ -694,7 +694,7 @@ let server
   >>=? fun () ->
   don't_wait_for
     (Connection.with_cleanup conn ~f:(fun () -> Connection.start_loops conn)
-     >>| Ivar.fill_exn conn.closed);
+     >>| Ivar.fill conn.closed);
   return (Ok conn)
 ;;
 

--- a/src/tls.ml
+++ b/src/tls.ml
@@ -254,7 +254,7 @@ module Expert = struct
          tls_settings
          where_to_connect
          ~f:(fun sock conn r w ->
-           Ivar.fill_exn conn_ivar (sock, conn, r, w);
+           Ivar.fill conn_ivar (sock, conn, r, w);
            Deferred.any [ Reader.close_finished r; Writer.close_finished w ]));
     Ivar.read conn_ivar
   ;;
@@ -264,7 +264,7 @@ module Expert = struct
     let finished =
       wrap_client_connection tls_settings outer_rd outer_wr ~f:(fun conn r w ->
         let%bind res, `Do_not_close_until finished = f conn r w in
-        Ivar.fill_exn result res;
+        Ivar.fill result res;
         finished)
     in
     let%map result = Ivar.read result in

--- a/stubgen/ffi_stubgen.ml
+++ b/stubgen/ffi_stubgen.ml
@@ -7,6 +7,7 @@ let prologue =
    #include <openssl/ssl.h>\n\
    #include <openssl/err.h>\n\
    #include <openssl/conf.h>\n\n\
+   #include <openssl/engine.h>\n\n\
    #include \"../bindings/openssl_helpers.h\"\n"
 ;;
 


### PR DESCRIPTION
Removed the Ctypes_foreign_threaded_stubs module as it was no longer used and was causing errors. Also changed Ivar.fill_exn to Ivar.fill as it was causing errors and Ivar.fill handles exceptions as well. Async_ssl now works with openssl 3.1.1, ocaml 5.0.0, ctypes 0.21.1 and ctypes-foreign 0.21.1