### PR TITLE
omit ldl on bsds

### DIFF
--- a/bindings/dune
+++ b/bindings/dune
@@ -10,7 +10,7 @@
  (deps discover.c openssl-ccopt openssl-cclib)
  (action
   (bash
-    "%{cc} $(< openssl-ccopt) discover.c $(< openssl-cclib) -ldl -o discover.exe")))
+    "%{cc} $(< openssl-ccopt) discover.c $(< openssl-cclib) $([[ $(uname) == *BSD ]] || echo -n -ldl) -o discover.exe")))
 
 (rule
  (targets config.h)


### PR DESCRIPTION
This fixes #32, as I was experiencing the same problem on my OpenBSD box. 

For the life of me, I couldn't figure out how to work with conditionals in dune, so forgive me if this is a tad on the ugly side.